### PR TITLE
Always use Class attribute

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in resizor.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,5 @@ Rake::TestTask.new(:test) do |t|
   t.pattern = 'test/*_test.rb'
   t.verbose = true
 end
+
+task default: :test

--- a/lib/resizor/railtie.rb
+++ b/lib/resizor/railtie.rb
@@ -20,6 +20,7 @@ module Resizor
   module Glue
     def self.included base
       base.extend ClassMethods
+      base.class_attribute(:resizor_assets)
     end
   end
 
@@ -28,11 +29,7 @@ module Resizor
       include InstanceMethods
 
       if resizor_assets.nil?
-        if active_support_three_dot_one?
-          self.resizor_assets = {}
-        else
-          write_inheritable_attribute(:resizor_assets, {})
-        end
+        self.resizor_assets = {}
       end
       resizor_assets[name] = options
 
@@ -50,22 +47,6 @@ module Resizor
       define_method "#{name}?" do
         !asset_for(name).file.nil? || !asset_for(name).id.nil?
       end
-
-    end
-
-    def resizor_assets
-      if active_support_three_dot_one?
-        class_attribute(:resizor_assets)
-        self.resizor_assets
-      else
-        read_inheritable_attribute(:resizor_assets)
-      end
-    end
-
-    def active_support_three_dot_one?
-      defined?(ActiveSupport::VERSION) &&
-        ActiveSupport::VERSION::MAJOR == 3 &&
-        ActiveSupport::VERSION::MINOR > 1
     end
   end
 

--- a/resizor.gemspec
+++ b/resizor.gemspec
@@ -13,12 +13,13 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = '>= 1.3.6'
 
-  s.add_development_dependency 'rake', '~> 0.9.2'
-  s.add_development_dependency 'sqlite3', '~> 1.3.4'
-  s.add_development_dependency 'bundler', '~> 1.0'
-  s.add_development_dependency 'shoulda', '~> 2.11.3'
-  s.add_development_dependency 'webmock', '~> 1.6.2'
-  s.add_development_dependency 'activerecord', '~>3.0.0'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'bundler'
+  s.add_development_dependency 'shoulda'
+  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'activerecord'
+  s.add_development_dependency 'minitest', '>= 5.5.1'
 
   s.add_dependency(%q<rest-client>, ['>= 1.4.2'])
   s.add_dependency(%q<json>, ['>= 1.2'])

--- a/test/asset_test.rb
+++ b/test/asset_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
-class ResizorAssetTest < Test::Unit::TestCase
+class ResizorAssetTest < Minitest::Test
   context "A ResizorAsset" do
     setup do
       setup_resizor

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
-class IntegrationTest < Test::Unit::TestCase
+class IntegrationTest < Minitest::Test
 
   context 'Including Resizor in a Rails project' do
     setup do
@@ -87,9 +87,7 @@ class IntegrationTest < Test::Unit::TestCase
     end
 
     should 'should work with no attachment set' do
-      assert_nothing_raised do
-        @item.save
-      end
+      @item.save
     end
 
     should 'return false when no attachment is set' do

--- a/test/resizor_test.rb
+++ b/test/resizor_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
-class ResizorTest < Test::Unit::TestCase
+class ResizorTest < Minitest::Test
   context 'When Resizor gem is not setup it' do
     setup do
       Resizor.instance_variable_set("@connection", nil)
@@ -8,7 +8,7 @@ class ResizorTest < Test::Unit::TestCase
 
     ['get', 'post', 'delete'].each do |m|
       should "raise error for #{m}" do
-        exception = assert_raise(RuntimeError) { Resizor.send(m, nil) }
+        exception = assert_raises(RuntimeError) { Resizor.send(m, nil) }
         assert_equal 'Not connected. Please setup Resizor configuration first.', exception.message
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,19 +1,19 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
-require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 require 'shoulda'
 require 'resizor'
+require 'logger'
 
-gem 'activerecord', '~>3.0.0'
+require 'active_support'
 require 'active_record'
 
-require 'webmock/test_unit'
+require 'webmock/minitest'
 include WebMock::API
 
 config = YAML::load(IO.read(File.dirname(__FILE__) + '/database.yml'))
-ActiveRecord::Base.logger = ActiveSupport::BufferedLogger.new(File.dirname(__FILE__) + "/debug.log")
+ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/debug.log")
 ActiveRecord::Base.establish_connection(config['test'])
 
 if defined?(Rails::Railtie)


### PR DESCRIPTION
This is required for Rails 4 compatibility, since the gem currently checks in a too naive way whether it should use `class_attribute`.
